### PR TITLE
Remove TDD specification test without implementation

### DIFF
--- a/src/test/java/com/solera/rubiogoncalves/airlinesapp/AirlinesAppApplicationTests.java
+++ b/src/test/java/com/solera/rubiogoncalves/airlinesapp/AirlinesAppApplicationTests.java
@@ -9,25 +9,5 @@ class AirlinesAppApplicationTests {
 	@Test
 	void contextLoads() {
 	}
-	
-	@Test
-	void testUserHasCredentials() {
-		
-		User myUser = new User(fname, sname, nation, id, age);
-		
-		assert(true, User.fname != "");
-		assert(true, User.sname != "");
-		assert(true, User.nationality != "");
-		assert(true, User.id != "");
-		assert(true, User.age >= 0);
-		
-	}
-	
-	@Test
-	void testCarryBags() {
-		double flightcost = 20.05;
-		flightcost = addCarryBag(flightcost);
-		if(flightcost > 20.05) assert(true);
-	}
 
 }


### PR DESCRIPTION
A specification test without its corresponding implementation was pushed to master, making the test run fail. This fixes that.